### PR TITLE
[RESTRICT AUTOMERGE] Restrict WifiDialogActivity

### DIFF
--- a/src/com/android/settings/wifi/WifiDialogActivity.java
+++ b/src/com/android/settings/wifi/WifiDialogActivity.java
@@ -17,6 +17,7 @@
 package com.android.settings.wifi;
 
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
+import static android.os.UserManager.DISALLOW_ADD_WIFI_CONFIG;
 import static android.os.UserManager.DISALLOW_CONFIG_WIFI;
 
 import android.app.KeyguardManager;
@@ -122,7 +123,7 @@ public class WifiDialogActivity extends ObservableActivity implements WifiDialog
         }
 
         super.onCreate(savedInstanceState);
-        if (!isConfigWifiAllowed()) {
+        if (!isConfigWifiAllowed() || !isAddWifiConfigAllowed()) {
             finish();
             return;
         }
@@ -391,6 +392,16 @@ public class WifiDialogActivity extends ObservableActivity implements WifiDialog
                     "The user is not allowed to configure Wi-Fi.");
         }
         return isConfigWifiAllowed;
+    }
+
+    @VisibleForTesting
+    boolean isAddWifiConfigAllowed() {
+        UserManager userManager = getSystemService(UserManager.class);
+        if (userManager != null && userManager.hasUserRestriction(DISALLOW_ADD_WIFI_CONFIG)) {
+            Log.e(TAG, "The user is not allowed to add Wi-Fi configuration.");
+            return false;
+        }
+        return true;
     }
 
     private boolean hasWifiManager() {

--- a/tests/robotests/src/com/android/settings/wifi/WifiDialogActivityTest.java
+++ b/tests/robotests/src/com/android/settings/wifi/WifiDialogActivityTest.java
@@ -18,6 +18,7 @@ package com.android.settings.wifi;
 
 import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
+import static android.os.UserManager.DISALLOW_ADD_WIFI_CONFIG;
 import static android.os.UserManager.DISALLOW_CONFIG_WIFI;
 
 import static com.android.settings.wifi.WifiDialogActivity.REQUEST_CODE_WIFI_DPP_ENROLLEE_QR_CODE_SCANNER;
@@ -240,6 +241,20 @@ public class WifiDialogActivityTest {
         when(mUserManager.hasUserRestriction(DISALLOW_CONFIG_WIFI)).thenReturn(true);
 
         assertThat(mActivity.isConfigWifiAllowed()).isFalse();
+    }
+
+    @Test
+    public void isAddWifiConfigAllowed_hasNoUserRestriction_returnTrue() {
+        when(mUserManager.hasUserRestriction(DISALLOW_ADD_WIFI_CONFIG)).thenReturn(false);
+
+        assertThat(mActivity.isAddWifiConfigAllowed()).isTrue();
+    }
+
+    @Test
+    public void isAddWifiConfigAllowed_hasUserRestriction_returnFalse() {
+        when(mUserManager.hasUserRestriction(DISALLOW_ADD_WIFI_CONFIG)).thenReturn(true);
+
+        assertThat(mActivity.isAddWifiConfigAllowed()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
- Don't show WifiDialogActivity if user has DISALLOW_ADD_WIFI_CONFIG

Bug: 299931761
Flag: None
Test: manual test with TestDPC
atest -c SettingsRoboTests:WifiDialogActivityTest

(cherry picked from commit 51fa3d798ad0397122bbb2143bc24efe1a705be9) (cherry picked from https://googleplex-android-review.googlesource.com/q/commit:a0409e582c30d2d6ff347eefd173ae169963df75) Merged-In: Icbb8f45922ded163208976be9c2816060dcf09f1 Change-Id: Icbb8f45922ded163208976be9c2816060dcf09f1